### PR TITLE
Upgrade taichi==0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can also export frames as PNGs to `output/{method}_{scene_init}/` by changin
 
 ## Dependencies
 
-- taichi==0.8.7
+- taichi==0.9.0
 - numpy
 - scipy
 - PyMCubes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-taichi==0.8.7
+taichi==0.9.0
 numpy
 scipy
 PyMCubes


### PR DESCRIPTION
Hi there!

Taichi developer here. We are really excited to see ETHZ is adopting Taichi! We have recently released https://github.com/taichi-dev/taichi/releases/tag/v0.9.0, and would like to make sure that Taichi is compatible with your project. I have tested `src/main.py` with `simulate_sand` turned both on and off in GGUI mode. FYI, here's my testing env:

```sh
python: 3.8.12 (default, Oct 12 2021, 13:49:34) 
[GCC 7.5.0]
system: linux
executable: /home/yekuang/miniconda3/envs/taichi/bin/python
platform: Linux-5.13.0-30-generic-x86_64-with-glibc2.17
architecture: 64bit ELF
uname: uname_result(system='Linux', node='yekuang-msi', release='5.13.0-30-generic', version='#33~20.04.1-Ubuntu SMP Mon Feb 7 14:25:10 UTC 2022', machine='x86_64', processor='x86_64')
locale: en_US.UTF-8
PATH: *
PYTHONPATH: *

No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 20.04.2 LTS
Release:	20.04
Codename:	focal
```

If you find any problem after upgrading Taichi, please do not hesitate to [file an issue](https://github.com/taichi-dev/taichi/issues). Thanks!

Best,
Ye